### PR TITLE
[review] checkout PR branch

### DIFF
--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -22,12 +22,11 @@ jobs:
         run: |
           apk --no-cache -u add git emacs-nox
       -
-        name: git special configs
-        run: |
-          git config --global --add safe.directory /__w/enats_msg/enats_msg
-      -
         name: Check out repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
       -
         name: format
         run: rebar3 fmt


### PR DESCRIPTION
The review workflow runs as on the `pull_request_target` trigger in order to have write permissions. But this also means it checks out the base branch by default.

Explicitly pull the changes from PR branch to run the formater on.